### PR TITLE
fix: align backend with frontend types, add change-password, fix security

### DIFF
--- a/.github/workflows/master_localhandsbackend.yml
+++ b/.github/workflows/master_localhandsbackend.yml
@@ -1,0 +1,65 @@
+# Docs for the Azure Web Apps Deploy action: https://github.com/Azure/webapps-deploy
+# More GitHub Actions for Azure: https://github.com/Azure/actions
+
+name: Build and deploy Node.js app to Azure Web App - localhandsbackend
+
+on:
+  push:
+    branches:
+      - master
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: windows-latest
+    permissions:
+      contents: read #This is required for actions/checkout
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Node.js version
+        uses: actions/setup-node@v3
+        with:
+          node-version: '22.x'
+
+      - name: npm install, build, and test
+        run: |
+          npm install
+          npm run build --if-present
+          npm run test --if-present
+      
+      - name: Upload artifact for deployment job
+        uses: actions/upload-artifact@v4
+        with:
+          name: node-app
+          path: .
+
+  deploy:
+    runs-on: ubuntu-latest
+    needs: build
+    permissions:
+      id-token: write #This is required for requesting the JWT
+      contents: read #This is required for actions/checkout
+
+    steps:
+      - name: Download artifact from build job
+        uses: actions/download-artifact@v4
+        with:
+          name: node-app
+      
+      - name: Login to Azure
+        uses: azure/login@v2
+        with:
+          client-id: ${{ secrets.AZUREAPPSERVICE_CLIENTID_19C3E9B89C7C401EA58A0ED16C6E34DB }}
+          tenant-id: ${{ secrets.AZUREAPPSERVICE_TENANTID_DEDC00F9A06849DAA8F1DD25C70E3ACB }}
+          subscription-id: ${{ secrets.AZUREAPPSERVICE_SUBSCRIPTIONID_41DE85B55FDA43BF892B179E50D586EE }}
+
+      - name: 'Deploy to Azure Web App'
+        uses: azure/webapps-deploy@v3
+        id: deploy-to-webapp
+        with:
+          app-name: 'localhandsbackend'
+          slot-name: 'Production'
+          package: .
+          

--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,7 @@ lerna-debug.log*
 !.vscode/extensions.json
 
 # dotenv environment variable files
+.env*
 .env
 .env.development.local
 .env.test.local

--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -1,7 +1,8 @@
-import { Controller, Post, Body, UseGuards, Get, Req } from '@nestjs/common';
+import { Controller, Post, Body, UseGuards, Get, Req, HttpCode, HttpStatus } from '@nestjs/common';
 import { Request } from 'express';
 import { AuthenticatedUser } from './user.interface';
 import { AuthService } from './auth.service';
+import { UserService } from '../user/user.service';
 import {
   ApiOperation,
   ApiResponse,
@@ -10,12 +11,16 @@ import {
 } from '@nestjs/swagger';
 import { LoginDto } from './dto/login.dto';
 import { CreateUserDto } from '../user/dto/create-user.dto';
+import { ChangePasswordDto } from './dto/change-password.dto';
 import { JwtAuthGuard } from './guards/jwt-auth.guard';
 
 @ApiTags('Authentication')
 @Controller('auth')
 export class AuthController {
-  constructor(private authService: AuthService) {}
+  constructor(
+    private authService: AuthService,
+    private userService: UserService,
+  ) {}
 
   @Post('register')
   @ApiOperation({
@@ -32,6 +37,7 @@ export class AuthController {
   }
 
   @Post('login')
+  @HttpCode(HttpStatus.OK)
   @ApiOperation({
     summary: 'User login',
     description: 'Authenticate a user and return a JWT token',
@@ -54,16 +60,31 @@ export class AuthController {
     status: 401,
     description: 'Unauthorized - Invalid or missing token',
   })
-  getProfile(@Req() req: Request) {
+  async getProfile(@Req() req: Request) {
     const user = req.user as AuthenticatedUser;
     if (!user) return { error: 'No user found' };
-    return {
-      id: user.id,
-      name: user.name,
-      email: user.email,
-      role: user.role,
-      avatar: user.avatar || null,
-      phoneNumber: user.phoneNumber || null,
-    };
+    return this.userService.findOne(user.id);
+  }
+
+  @Post('change-password')
+  @UseGuards(JwtAuthGuard)
+  @ApiBearerAuth('access-token')
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({
+    summary: 'Change password',
+    description: 'Change the password of the currently authenticated user',
+  })
+  @ApiResponse({ status: 200, description: 'Password changed successfully' })
+  @ApiResponse({ status: 400, description: 'Current password is incorrect' })
+  async changePassword(
+    @Req() req: Request,
+    @Body() changePasswordDto: ChangePasswordDto,
+  ) {
+    const user = req.user as AuthenticatedUser;
+    return this.authService.changePassword(
+      user.id,
+      changePasswordDto.currentPassword,
+      changePasswordDto.newPassword,
+    );
   }
 }

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -1,4 +1,8 @@
-import { Injectable, ForbiddenException } from '@nestjs/common';
+import {
+  Injectable,
+  ForbiddenException,
+  BadRequestException,
+} from '@nestjs/common';
 import { JwtService } from '@nestjs/jwt';
 import { User } from '@prisma/client';
 import * as bcrypt from 'bcrypt';
@@ -22,7 +26,6 @@ export class AuthService {
     password: string,
   ): Promise<Omit<User, 'passwordHash'> | null> {
     let user: User;
-    // Try to find user by email or phone number
     try {
       if (identifier.includes('@')) {
         user = await this.usersService.findByEmail(identifier);
@@ -52,15 +55,40 @@ export class AuthService {
       throw new ForbiddenException('Invalid credentials');
     }
 
+    await this.usersService.updateLastLogin(validatedUser.id);
+
     const payload = {
       email: validatedUser.email,
       phoneNumber: validatedUser.phoneNumber,
       sub: validatedUser.id,
+      name: validatedUser.name,
+      role: validatedUser.role,
     };
 
     return {
       access_token: this.jwtService.sign(payload),
       user: validatedUser,
     };
+  }
+
+  async changePassword(
+    userId: number,
+    currentPassword: string,
+    newPassword: string,
+  ) {
+    const user = await this.usersService.findOneWithPassword(userId);
+
+    const isPasswordValid = await bcrypt.compare(
+      currentPassword,
+      user.passwordHash,
+    );
+    if (!isPasswordValid) {
+      throw new BadRequestException('Current password is incorrect');
+    }
+
+    const passwordHash = await bcrypt.hash(newPassword, 10);
+    await this.usersService.update(userId, { passwordHash } as any);
+
+    return { message: 'Password changed successfully' };
   }
 }

--- a/src/auth/dto/change-password.dto.ts
+++ b/src/auth/dto/change-password.dto.ts
@@ -1,0 +1,15 @@
+import { IsString, IsNotEmpty, Length } from 'class-validator';
+import { ApiProperty } from '@nestjs/swagger';
+
+export class ChangePasswordDto {
+  @ApiProperty({ example: 'oldpassword123' })
+  @IsString()
+  @IsNotEmpty()
+  currentPassword: string;
+
+  @ApiProperty({ example: 'newpassword456' })
+  @IsString()
+  @IsNotEmpty()
+  @Length(8, 100, { message: 'New password must be at least 8 characters long' })
+  newPassword: string;
+}

--- a/src/auth/strategies/jwt.strategy.ts
+++ b/src/auth/strategies/jwt.strategy.ts
@@ -13,6 +13,12 @@ export class JwtStrategy extends PassportStrategy(Strategy) {
   }
 
   async validate(payload: any) {
-    return { id: payload.sub, email: payload.email };
+    return {
+      id: payload.sub,
+      email: payload.email,
+      name: payload.name,
+      role: payload.role,
+      phoneNumber: payload.phoneNumber,
+    };
   }
 }

--- a/src/auth/user.interface.ts
+++ b/src/auth/user.interface.ts
@@ -1,8 +1,7 @@
 export interface AuthenticatedUser {
-  id: string;
+  id: number;
   name: string;
   email: string;
   role: string;
-  avatar?: string;
   phoneNumber?: string;
 }

--- a/src/config/server.config.ts
+++ b/src/config/server.config.ts
@@ -4,7 +4,7 @@ export const ServerConfig = registerAs(
   'server',
   (): ServerConfig => ({
     nodeEnv: process.env.NODE_ENV || 'development',
-    port: parseInt(process.env.PORT || '3000', 10),
+    port: parseInt(process.env.PORT || '5000', 10),
     corsOrigin: process.env.CORS_ORIGIN || '*',
   }),
 );

--- a/src/settings/dto/system-settings.dto.ts
+++ b/src/settings/dto/system-settings.dto.ts
@@ -1,26 +1,42 @@
-import { IsBoolean, IsString, IsNumber, IsIn } from 'class-validator';
+import { IsBoolean, IsString, IsNumber, IsOptional } from 'class-validator';
+import { ApiProperty } from '@nestjs/swagger';
 
 export class SystemSettingsDto {
+  @ApiProperty({ example: false })
   @IsBoolean()
   maintenance_mode: boolean;
 
+  @ApiProperty({ example: true })
   @IsBoolean()
   allow_registration: boolean;
 
+  @ApiProperty({ example: false })
   @IsBoolean()
   review_auto_approve: boolean;
 
+  @ApiProperty({ example: 'fapshi' })
   @IsString()
-  @IsIn(['stripe', 'paypal'])
   payment_gateway: string;
 
+  @ApiProperty({ example: true })
   @IsBoolean()
   email_notifications: boolean;
 
+  @ApiProperty({ example: 5 })
   @IsNumber()
   max_file_size: number;
 
+  @ApiProperty({ example: 'XAF' })
   @IsString()
-  @IsIn(['USD', 'EUR', 'GBP'])
   currency: string;
+
+  @ApiProperty({ example: 'FCFA', required: false })
+  @IsOptional()
+  @IsString()
+  currency_symbol?: string;
+
+  @ApiProperty({ example: 'support@localhands.com', required: false })
+  @IsOptional()
+  @IsString()
+  supportEmail?: string;
 }

--- a/src/settings/settings.service.ts
+++ b/src/settings/settings.service.ts
@@ -9,32 +9,48 @@ export class SettingsService {
   async getSystemSettings() {
     const settings = await this.prisma.systemSettings.findFirst();
     if (!settings) {
-      // Return default settings if none exist
       return {
-        maintenance_mode: false,
-        allow_registration: true,
-        review_auto_approve: false,
-        payment_gateway: 'stripe',
-        email_notifications: true,
-        max_file_size: 5,
-        currency: 'USD',
+        maintenanceMode: false,
+        allowRegistration: true,
+        reviewAutoApprove: false,
+        paymentGateway: 'fapshi',
+        emailNotifications: true,
+        maxFileSize: 5,
+        currency: 'XAF',
+        currencySymbol: 'FCFA',
+        supportEmail: null,
       };
     }
-    return settings;
+    return {
+      id: settings.id,
+      maintenanceMode: settings.maintenance_mode,
+      allowRegistration: settings.allow_registration,
+      reviewAutoApprove: settings.review_auto_approve,
+      paymentGateway: settings.payment_gateway,
+      emailNotifications: settings.email_notifications,
+      maxFileSize: settings.max_file_size,
+      currency: settings.currency,
+      currencySymbol: settings.currency_symbol,
+      supportEmail: settings.supportEmail,
+      createdAt: settings.createdAt,
+      updatedAt: settings.updatedAt,
+    };
   }
 
   async updateSystemSettings(settings: SystemSettingsDto) {
     const existingSettings = await this.prisma.systemSettings.findFirst();
 
     if (existingSettings) {
-      return this.prisma.systemSettings.update({
+      await this.prisma.systemSettings.update({
         where: { id: existingSettings.id },
+        data: settings,
+      });
+    } else {
+      await this.prisma.systemSettings.create({
         data: settings,
       });
     }
 
-    return this.prisma.systemSettings.create({
-      data: settings,
-    });
+    return this.getSystemSettings();
   }
 }

--- a/src/user/user.service.ts
+++ b/src/user/user.service.ts
@@ -4,6 +4,7 @@ import {
   ConflictException,
 } from '@nestjs/common';
 import { PrismaService } from '../prisma/prisma.service';
+import { User } from '@prisma/client';
 import * as bcrypt from 'bcrypt';
 import { CreateUserDto } from './dto/create-user.dto';
 import { UpdateUserDto } from './dto/update-user.dto';
@@ -43,9 +44,11 @@ export class UserService {
       },
       select: {
         id: true,
+        name: true,
         email: true,
         phoneNumber: true,
         role: true,
+        createdAt: true,
         profile: {
           omit: {
             bankAccountNumber: true,
@@ -60,8 +63,11 @@ export class UserService {
 
   async findAll() {
     return this.prisma.user.findMany({
+      omit: {
+        passwordHash: true,
+      },
       include: {
-        profile: true, // Include the user's profile in the response
+        profile: true,
       },
     });
   }
@@ -69,8 +75,24 @@ export class UserService {
   async findOne(id: number) {
     const user = await this.prisma.user.findUnique({
       where: { id },
+      omit: {
+        passwordHash: true,
+      },
       include: {
-        profile: true, // Include the user's profile in the response
+        profile: true,
+      },
+    });
+    if (!user) {
+      throw new NotFoundException(`User with ID ${id} not found`);
+    }
+    return user;
+  }
+
+  async findOneWithPassword(id: number): Promise<User> {
+    const user = await this.prisma.user.findUnique({
+      where: { id },
+      include: {
+        profile: true,
       },
     });
     if (!user) {
@@ -112,6 +134,9 @@ export class UserService {
     return this.prisma.user.update({
       where: { id },
       data: updateUserDto,
+      omit: {
+        passwordHash: true,
+      },
     });
   }
 
@@ -123,14 +148,22 @@ export class UserService {
       throw new NotFoundException(`User with ID ${id} not found`);
     }
 
-    // Delete the user's profile first (if it exists)
     await this.prisma.profile.delete({
       where: { userId: id },
     });
 
-    // Delete the user
     return this.prisma.user.delete({
       where: { id },
+      omit: {
+        passwordHash: true,
+      },
+    });
+  }
+
+  async updateLastLogin(id: number) {
+    return this.prisma.user.update({
+      where: { id },
+      data: { lastLogin: new Date() },
     });
   }
 


### PR DESCRIPTION
- Expand JWT payload & strategy to include name, role, phoneNumber.
- /auth/profile now returns full user from DB instead of truncated object.
- Add POST /auth/change-password endpoint with JWT guard.
- Fix SystemSettingsDto  allow fapshi gateway and XAF currency.
- Map settings service responses to camelCase for frontend consumption.
- Omit passwordHash from all public user queries (findOne, findAll, update, remove).
- Include name and createdAt in registration response.
- Update lastLogin timestamp on successful login.
- Fix AuthenticatedUser interface  correct id type, remove non-existent avatar field.