### PR TITLE
fix: register SettingsModule and align DTO camelCase with frontend

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -22,6 +22,7 @@ import { PaymentModule } from './payment/payment.module';
 import { CommonModule } from './common/common.module';
 import { HealthModule } from './health/health.module';
 import { ClientModule } from './client/client.module';
+import { SettingsModule } from './settings/settings.module';
 import { PaymentConfig } from './config/payment.config';
 import { ServerConfig } from './config/server.config';
 
@@ -53,6 +54,7 @@ import { ServerConfig } from './config/server.config';
     CommonModule,
     HealthModule,
     ClientModule,
+    SettingsModule,
   ],
   controllers: [AppController],
   providers: [],

--- a/src/settings/dto/system-settings.dto.ts
+++ b/src/settings/dto/system-settings.dto.ts
@@ -4,27 +4,27 @@ import { ApiProperty } from '@nestjs/swagger';
 export class SystemSettingsDto {
   @ApiProperty({ example: false })
   @IsBoolean()
-  maintenance_mode: boolean;
+  maintenanceMode: boolean;
 
   @ApiProperty({ example: true })
   @IsBoolean()
-  allow_registration: boolean;
+  allowRegistration: boolean;
 
   @ApiProperty({ example: false })
   @IsBoolean()
-  review_auto_approve: boolean;
+  reviewAutoApprove: boolean;
 
   @ApiProperty({ example: 'fapshi' })
   @IsString()
-  payment_gateway: string;
+  paymentGateway: string;
 
   @ApiProperty({ example: true })
   @IsBoolean()
-  email_notifications: boolean;
+  emailNotifications: boolean;
 
   @ApiProperty({ example: 5 })
   @IsNumber()
-  max_file_size: number;
+  maxFileSize: number;
 
   @ApiProperty({ example: 'XAF' })
   @IsString()
@@ -33,7 +33,7 @@ export class SystemSettingsDto {
   @ApiProperty({ example: 'FCFA', required: false })
   @IsOptional()
   @IsString()
-  currency_symbol?: string;
+  currencySymbol?: string;
 
   @ApiProperty({ example: 'support@localhands.com', required: false })
   @IsOptional()

--- a/src/settings/settings.service.ts
+++ b/src/settings/settings.service.ts
@@ -37,17 +37,29 @@ export class SettingsService {
     };
   }
 
-  async updateSystemSettings(settings: SystemSettingsDto) {
+  async updateSystemSettings(dto: SystemSettingsDto) {
     const existingSettings = await this.prisma.systemSettings.findFirst();
+
+    const data = {
+      maintenance_mode: dto.maintenanceMode,
+      allow_registration: dto.allowRegistration,
+      review_auto_approve: dto.reviewAutoApprove,
+      payment_gateway: dto.paymentGateway,
+      email_notifications: dto.emailNotifications,
+      max_file_size: dto.maxFileSize,
+      currency: dto.currency,
+      currency_symbol: dto.currencySymbol,
+      supportEmail: dto.supportEmail,
+    };
 
     if (existingSettings) {
       await this.prisma.systemSettings.update({
         where: { id: existingSettings.id },
-        data: settings,
+        data,
       });
     } else {
       await this.prisma.systemSettings.create({
-        data: settings,
+        data,
       });
     }
 


### PR DESCRIPTION
SettingsModule existed but was never imported in AppModule,

making GET/PUT /api/settings/system unreachable.

Also updated SystemSettingsDto to accept camelCase fields

matching the GET response and frontend types. Service

now maps camelCase DTO to snake_case before Prisma write.