### PR TITLE
fix: implement stubbed services & add query filters across controllers

### DIFF
--- a/src/booking/booking.controller.ts
+++ b/src/booking/booking.controller.ts
@@ -6,6 +6,7 @@ import {
   Patch,
   Param,
   Delete,
+  Query,
   HttpCode,
   HttpStatus,
 } from '@nestjs/common';
@@ -39,10 +40,10 @@ export class BookingController {
 
   @Get()
   @HttpCode(HttpStatus.OK)
-  @ApiOperation({ summary: 'Retrieve all bookings' })
+  @ApiOperation({ summary: 'Retrieve all bookings, optionally filtered by client' })
   @ApiResponse({ status: 200, description: 'List of all bookings.' })
-  findAll() {
-    return this.bookingService.findAll();
+  findAll(@Query('clientId') clientId?: string) {
+    return this.bookingService.findAll({ clientId });
   }
 
   @UseGuards(JwtAuthGuard)

--- a/src/booking/booking.service.ts
+++ b/src/booking/booking.service.ts
@@ -40,8 +40,13 @@ export class BookingService {
     });
   }
 
-  async findAll() {
+  async findAll(filters?: { clientId?: string }) {
+    const where: any = {};
+    if (filters?.clientId) {
+      where.clientId = Number(filters.clientId);
+    }
     return this.prisma.booking.findMany({
+      where,
       include: {
         service: true, // Include service details
         client: true, // Include client details

--- a/src/contract/contract.controller.ts
+++ b/src/contract/contract.controller.ts
@@ -6,6 +6,7 @@ import {
   Patch,
   Param,
   Delete,
+  Query,
   HttpCode,
   HttpStatus,
 } from '@nestjs/common';
@@ -36,10 +37,10 @@ export class ContractController {
 
   @Get()
   @HttpCode(HttpStatus.OK)
-  @ApiOperation({ summary: 'Retrieve all contracts' })
+  @ApiOperation({ summary: 'Retrieve all contracts, optionally filtered by status' })
   @ApiResponse({ status: 200, description: 'List of all contracts.' })
-  findAll() {
-    return this.contractService.findAll();
+  findAll(@Query('status') status?: string) {
+    return this.contractService.findAll({ status });
   }
 
   @UseGuards(JwtAuthGuard)

--- a/src/contract/contract.service.ts
+++ b/src/contract/contract.service.ts
@@ -21,8 +21,13 @@ export class ContractService {
     });
   }
 
-  async findAll() {
+  async findAll(filters?: { status?: string }) {
+    const where: any = {};
+    if (filters?.status) {
+      where.status = filters.status;
+    }
     return this.prisma.contract.findMany({
+      where,
       include: { serviceOrder: true, users: true },
     });
   }

--- a/src/messages/messages.controller.ts
+++ b/src/messages/messages.controller.ts
@@ -6,39 +6,75 @@ import {
   Patch,
   Param,
   Delete,
+  Query,
+  HttpCode,
+  HttpStatus,
+  UseGuards,
 } from '@nestjs/common';
 import { MessagesService } from './messages.service';
 import { CreateMessageDto } from './dto/create-message.dto';
 import { UpdateMessageDto } from './dto/update-message.dto';
+import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
+import { ApiBearerAuth, ApiTags, ApiOperation, ApiResponse } from '@nestjs/swagger';
 
+@ApiTags('Messages')
 @Controller('messages')
 export class MessagesController {
   constructor(private readonly messagesService: MessagesService) {}
 
+  @UseGuards(JwtAuthGuard)
+  @ApiBearerAuth()
   @Post()
+  @HttpCode(HttpStatus.CREATED)
+  @ApiOperation({ summary: 'Create a new message' })
+  @ApiResponse({ status: 201, description: 'The message has been successfully created.' })
+  @ApiResponse({ status: 404, description: 'Sender or receiver not found.' })
   create(@Body() createMessageDto: CreateMessageDto) {
     return this.messagesService.create(createMessageDto);
   }
 
+  @UseGuards(JwtAuthGuard)
+  @ApiBearerAuth()
   @Get()
-  findAll() {
-    return this.messagesService.findAll();
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({ summary: 'Retrieve all messages, optionally filtered by sender or receiver' })
+  @ApiResponse({ status: 200, description: 'List of messages.' })
+  findAll(
+    @Query('senderId') senderId?: string,
+    @Query('receiverId') receiverId?: string,
+  ) {
+    return this.messagesService.findAll({ senderId, receiverId });
   }
 
+  @UseGuards(JwtAuthGuard)
+  @ApiBearerAuth()
   @Get(':id')
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({ summary: 'Retrieve a specific message by ID' })
+  @ApiResponse({ status: 200, description: 'The message has been successfully retrieved.' })
+  @ApiResponse({ status: 404, description: 'Message not found.' })
   findOne(@Param('id') id: string) {
     return this.messagesService.findOne(+id);
   }
 
+  @UseGuards(JwtAuthGuard)
+  @ApiBearerAuth()
   @Patch(':id')
-  update(
-    @Param('id') id: string,
-    @Body() updateMessageDto: UpdateMessageDto,
-  ) {
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({ summary: 'Update a specific message by ID' })
+  @ApiResponse({ status: 200, description: 'The message has been successfully updated.' })
+  @ApiResponse({ status: 404, description: 'Message not found.' })
+  update(@Param('id') id: string, @Body() updateMessageDto: UpdateMessageDto) {
     return this.messagesService.update(+id, updateMessageDto);
   }
 
+  @UseGuards(JwtAuthGuard)
+  @ApiBearerAuth()
   @Delete(':id')
+  @HttpCode(HttpStatus.NO_CONTENT)
+  @ApiOperation({ summary: 'Delete a specific message by ID' })
+  @ApiResponse({ status: 204, description: 'The message has been successfully deleted.' })
+  @ApiResponse({ status: 404, description: 'Message not found.' })
   remove(@Param('id') id: string) {
     return this.messagesService.remove(+id);
   }

--- a/src/messages/messages.module.ts
+++ b/src/messages/messages.module.ts
@@ -1,8 +1,10 @@
 import { Module } from '@nestjs/common';
 import { MessagesService } from './messages.service';
 import { MessagesController } from './messages.controller';
+import { PrismaModule } from '../prisma/prisma.module';
 
 @Module({
+  imports: [PrismaModule],
   controllers: [MessagesController],
   providers: [MessagesService],
 })

--- a/src/messages/messages.service.ts
+++ b/src/messages/messages.service.ts
@@ -1,26 +1,71 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, NotFoundException } from '@nestjs/common';
+import { PrismaService } from '../prisma/prisma.service';
 import { CreateMessageDto } from './dto/create-message.dto';
 import { UpdateMessageDto } from './dto/update-message.dto';
 
 @Injectable()
 export class MessagesService {
-  create(createMessageDto: CreateMessageDto) {
-    return 'This action adds a new message';
+  constructor(private readonly prisma: PrismaService) {}
+
+  async create(createMessageDto: CreateMessageDto) {
+    const { senderId, receiverId, content } = createMessageDto;
+
+    const sender = await this.prisma.user.findUnique({ where: { id: senderId } });
+    if (!sender) {
+      throw new NotFoundException(`Sender with ID ${senderId} not found`);
+    }
+
+    const receiver = await this.prisma.user.findUnique({ where: { id: receiverId } });
+    if (!receiver) {
+      throw new NotFoundException(`Receiver with ID ${receiverId} not found`);
+    }
+
+    return this.prisma.message.create({
+      data: { senderId, receiverId, content },
+      include: { sender: true, receiver: true },
+    });
   }
 
-  findAll() {
-    return `This action returns all messages`;
+  async findAll(filters?: { senderId?: string; receiverId?: string }) {
+    const where: any = {};
+    if (filters?.senderId) where.senderId = Number(filters.senderId);
+    if (filters?.receiverId) where.receiverId = Number(filters.receiverId);
+
+    return this.prisma.message.findMany({
+      where,
+      include: { sender: true, receiver: true },
+      orderBy: { timestamp: 'asc' },
+    });
   }
 
-  findOne(id: number) {
-    return `This action returns a #${id} message`;
+  async findOne(id: number) {
+    const message = await this.prisma.message.findUnique({
+      where: { id },
+      include: { sender: true, receiver: true },
+    });
+    if (!message) {
+      throw new NotFoundException(`Message with ID ${id} not found`);
+    }
+    return message;
   }
 
-  update(id: number, updateMessageDto: UpdateMessageDto) {
-    return `This action updates a #${id} message`;
+  async update(id: number, updateMessageDto: UpdateMessageDto) {
+    const message = await this.prisma.message.findUnique({ where: { id } });
+    if (!message) {
+      throw new NotFoundException(`Message with ID ${id} not found`);
+    }
+    return this.prisma.message.update({
+      where: { id },
+      data: updateMessageDto,
+      include: { sender: true, receiver: true },
+    });
   }
 
-  remove(id: number) {
-    return `This action removes a #${id} message`;
+  async remove(id: number) {
+    const message = await this.prisma.message.findUnique({ where: { id } });
+    if (!message) {
+      throw new NotFoundException(`Message with ID ${id} not found`);
+    }
+    return this.prisma.message.delete({ where: { id } });
   }
 }

--- a/src/notifications/notifications.controller.ts
+++ b/src/notifications/notifications.controller.ts
@@ -6,39 +6,75 @@ import {
   Patch,
   Param,
   Delete,
+  Query,
+  HttpCode,
+  HttpStatus,
+  UseGuards,
 } from '@nestjs/common';
 import { NotificationsService } from './notifications.service';
 import { CreateNotificationDto } from './dto/create-notification.dto';
 import { UpdateNotificationDto } from './dto/update-notification.dto';
+import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
+import { ApiBearerAuth, ApiTags, ApiOperation, ApiResponse } from '@nestjs/swagger';
 
+@ApiTags('Notifications')
 @Controller('notifications')
 export class NotificationsController {
   constructor(private readonly notificationsService: NotificationsService) {}
 
+  @UseGuards(JwtAuthGuard)
+  @ApiBearerAuth()
   @Post()
+  @HttpCode(HttpStatus.CREATED)
+  @ApiOperation({ summary: 'Create a new notification' })
+  @ApiResponse({ status: 201, description: 'The notification has been successfully created.' })
+  @ApiResponse({ status: 404, description: 'User not found.' })
   create(@Body() createNotificationDto: CreateNotificationDto) {
     return this.notificationsService.create(createNotificationDto);
   }
 
+  @UseGuards(JwtAuthGuard)
+  @ApiBearerAuth()
   @Get()
-  findAll() {
-    return this.notificationsService.findAll();
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({ summary: 'Retrieve all notifications, optionally filtered by user' })
+  @ApiResponse({ status: 200, description: 'List of notifications.' })
+  findAll(
+    @Query('userId') userId?: string,
+    @Query('read') read?: string,
+  ) {
+    return this.notificationsService.findAll({ userId, read });
   }
 
+  @UseGuards(JwtAuthGuard)
+  @ApiBearerAuth()
   @Get(':id')
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({ summary: 'Retrieve a specific notification by ID' })
+  @ApiResponse({ status: 200, description: 'The notification has been successfully retrieved.' })
+  @ApiResponse({ status: 404, description: 'Notification not found.' })
   findOne(@Param('id') id: string) {
     return this.notificationsService.findOne(+id);
   }
 
+  @UseGuards(JwtAuthGuard)
+  @ApiBearerAuth()
   @Patch(':id')
-  update(
-    @Param('id') id: string,
-    @Body() updateNotificationDto: UpdateNotificationDto,
-  ) {
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({ summary: 'Update a specific notification by ID' })
+  @ApiResponse({ status: 200, description: 'The notification has been successfully updated.' })
+  @ApiResponse({ status: 404, description: 'Notification not found.' })
+  update(@Param('id') id: string, @Body() updateNotificationDto: UpdateNotificationDto) {
     return this.notificationsService.update(+id, updateNotificationDto);
   }
 
+  @UseGuards(JwtAuthGuard)
+  @ApiBearerAuth()
   @Delete(':id')
+  @HttpCode(HttpStatus.NO_CONTENT)
+  @ApiOperation({ summary: 'Delete a specific notification by ID' })
+  @ApiResponse({ status: 204, description: 'The notification has been successfully deleted.' })
+  @ApiResponse({ status: 404, description: 'Notification not found.' })
   remove(@Param('id') id: string) {
     return this.notificationsService.remove(+id);
   }

--- a/src/notifications/notifications.module.ts
+++ b/src/notifications/notifications.module.ts
@@ -1,8 +1,10 @@
 import { Module } from '@nestjs/common';
 import { NotificationsService } from './notifications.service';
 import { NotificationsController } from './notifications.controller';
+import { PrismaModule } from '../prisma/prisma.module';
 
 @Module({
+  imports: [PrismaModule],
   controllers: [NotificationsController],
   providers: [NotificationsService],
 })

--- a/src/notifications/notifications.service.ts
+++ b/src/notifications/notifications.service.ts
@@ -1,26 +1,66 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, NotFoundException } from '@nestjs/common';
+import { PrismaService } from '../prisma/prisma.service';
 import { CreateNotificationDto } from './dto/create-notification.dto';
 import { UpdateNotificationDto } from './dto/update-notification.dto';
 
 @Injectable()
 export class NotificationsService {
-  create(createNotificationDto: CreateNotificationDto) {
-    return 'This action adds a new notification';
+  constructor(private readonly prisma: PrismaService) {}
+
+  async create(createNotificationDto: CreateNotificationDto) {
+    const { userId, message, type } = createNotificationDto;
+
+    const user = await this.prisma.user.findUnique({ where: { id: userId } });
+    if (!user) {
+      throw new NotFoundException(`User with ID ${userId} not found`);
+    }
+
+    return this.prisma.notification.create({
+      data: { userId, message, type },
+      include: { user: true },
+    });
   }
 
-  findAll() {
-    return `This action returns all notifications`;
+  async findAll(filters?: { userId?: string; read?: string }) {
+    const where: any = {};
+    if (filters?.userId) where.userId = Number(filters.userId);
+    if (filters?.read !== undefined) where.read = filters.read === 'true';
+
+    return this.prisma.notification.findMany({
+      where,
+      include: { user: true },
+      orderBy: { createdAt: 'desc' },
+    });
   }
 
-  findOne(id: number) {
-    return `This action returns a #${id} notification`;
+  async findOne(id: number) {
+    const notification = await this.prisma.notification.findUnique({
+      where: { id },
+      include: { user: true },
+    });
+    if (!notification) {
+      throw new NotFoundException(`Notification with ID ${id} not found`);
+    }
+    return notification;
   }
 
-  update(id: number, updateNotificationDto: UpdateNotificationDto) {
-    return `This action updates a #${id} notification`;
+  async update(id: number, updateNotificationDto: UpdateNotificationDto) {
+    const notification = await this.prisma.notification.findUnique({ where: { id } });
+    if (!notification) {
+      throw new NotFoundException(`Notification with ID ${id} not found`);
+    }
+    return this.prisma.notification.update({
+      where: { id },
+      data: updateNotificationDto,
+      include: { user: true },
+    });
   }
 
-  remove(id: number) {
-    return `This action removes a #${id} notification`;
+  async remove(id: number) {
+    const notification = await this.prisma.notification.findUnique({ where: { id } });
+    if (!notification) {
+      throw new NotFoundException(`Notification with ID ${id} not found`);
+    }
+    return this.prisma.notification.delete({ where: { id } });
   }
 }

--- a/src/proposal/proposal.controller.ts
+++ b/src/proposal/proposal.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Get, Post, Body, Patch, Param, Delete, HttpCode, HttpStatus } from '@nestjs/common';
+import { Controller, Get, Post, Body, Patch, Param, Delete, Query, HttpCode, HttpStatus } from '@nestjs/common';
 import { ProposalService } from './proposal.service';
 import { UseGuards } from '@nestjs/common';
 import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
@@ -26,9 +26,11 @@ export class ProposalController {
 
   @Get()
   @HttpCode(HttpStatus.OK)
-  @ApiOperation({ summary: 'Retrieve all proposals' })
+  @ApiOperation({ summary: 'Retrieve all proposals, optionally filtered by provider' })
   @ApiResponse({ status: 200, description: 'List of all proposals.' })
-  findAll() { return this.proposalService.findAll(); }
+  findAll(@Query('providerId') providerId?: string) {
+    return this.proposalService.findAll({ providerId });
+  }
 
   @UseGuards(JwtAuthGuard)
   @ApiBearerAuth()

--- a/src/proposal/proposal.service.ts
+++ b/src/proposal/proposal.service.ts
@@ -18,7 +18,13 @@ export class ProposalService {
     });
   }
 
-  async findAll() { return this.prisma.proposal.findMany({ include: { provider: true, service: true } }); }
+  async findAll(filters?: { providerId?: string }) {
+    const where: any = {};
+    if (filters?.providerId) {
+      where.providerId = Number(filters.providerId);
+    }
+    return this.prisma.proposal.findMany({ where, include: { provider: true, service: true } });
+  }
 
   async findOne(id: number) {
     const proposal = await this.prisma.proposal.findUnique({ where: { id }, include: { provider: true, service: true } });

--- a/src/service/service.controller.ts
+++ b/src/service/service.controller.ts
@@ -62,6 +62,15 @@ export class ServiceController {
     return this.serviceService.findByProvider(+providerId);
   }
 
+  @Get('featured')
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({ summary: 'Get featured services' })
+  @ApiResponse({ status: 200, description: 'List of featured services.' })
+  async findFeatured(@Query('limit') limit?: string) {
+    const limitNum = limit ? parseInt(limit, 10) : 6;
+    return this.serviceService.findFeatured(limitNum);
+  }
+
   @Get(':id')
   @HttpCode(HttpStatus.OK)
   @ApiOperation({ summary: 'Retrieve a specific service by ID' })
@@ -140,14 +149,5 @@ export class ServiceController {
   @ApiResponse({ status: 404, description: 'Service not found.' })
   incrementViews(@Param('id') id: string) {
     return this.serviceService.incrementViews(+id);
-  }
-
-  @Get('featured')
-  @HttpCode(HttpStatus.OK)
-  @ApiOperation({ summary: 'Get featured services' })
-  @ApiResponse({ status: 200, description: 'List of featured services.' })
-  async findFeatured(@Query('limit') limit?: string) {
-    const limitNum = limit ? parseInt(limit, 10) : 6;
-    return this.serviceService.findFeatured(limitNum);
   }
 }

--- a/src/serviceorder/serviceorder.controller.ts
+++ b/src/serviceorder/serviceorder.controller.ts
@@ -6,6 +6,7 @@ import {
   Patch,
   Param,
   Delete,
+  Query,
   HttpCode,
   HttpStatus,
 } from '@nestjs/common';
@@ -33,10 +34,13 @@ export class ServiceorderController {
 
   @Get()
   @HttpCode(HttpStatus.OK)
-  @ApiOperation({ summary: 'Retrieve all service orders' })
+  @ApiOperation({ summary: 'Retrieve all service orders, optionally filtered by status or client' })
   @ApiResponse({ status: 200, description: 'List of all service orders.' })
-  findAll() {
-    return this.serviceorderService.findAll();
+  findAll(
+    @Query('status') status?: string,
+    @Query('clientId') clientId?: string,
+  ) {
+    return this.serviceorderService.findAll({ status, clientId });
   }
 
   @Get(':id')

--- a/src/serviceorder/serviceorder.service.ts
+++ b/src/serviceorder/serviceorder.service.ts
@@ -38,8 +38,17 @@ export class ServiceorderService {
     });
   }
 
-  async findAll() {
+  async findAll(filters?: { status?: string; clientId?: string }) {
+    const where: any = {};
+    if (filters?.status) {
+      where.status = filters.status;
+    }
+    if (filters?.clientId) {
+      where.clientId = Number(filters.clientId);
+    }
+
     return this.prisma.serviceOrder.findMany({
+      where,
       include: {
         service: true, // Include service details
         client: true, // Include client details


### PR DESCRIPTION
- Implement messages.service.ts and notifications.service.ts with full Prisma CRUD
- Fix service controller route ordering (featured before :id)
- Add @Query() filtering to serviceorder, proposal, booking, and contract controllers
- Add JWT guards to messages and notifications endpoints
- Add PrismaModule imports to messages and notifications modules