### PR TITLE
fix: forward validation error details in API responses and log them

### DIFF
--- a/src/common/filters/all-exceptions.filter.ts
+++ b/src/common/filters/all-exceptions.filter.ts
@@ -21,6 +21,8 @@ export class AllExceptionsFilter implements ExceptionFilter {
     let status = HttpStatus.INTERNAL_SERVER_ERROR;
     let message = 'Internal server error';
 
+    let errors: any = undefined;
+
     if (exception instanceof HttpException) {
       status = exception.getStatus();
       const errorResponse = exception.getResponse();
@@ -31,6 +33,17 @@ export class AllExceptionsFilter implements ExceptionFilter {
             ? errorResponse['message'][0]
             : errorResponse['message']
           : exception.message;
+
+      if (
+        typeof errorResponse === 'object' &&
+        errorResponse !== null &&
+        'errors' in errorResponse
+      ) {
+        errors = errorResponse['errors'];
+        this.logger.error(
+          `Validation errors: ${JSON.stringify(errors)}`,
+        );
+      }
     } else if (exception instanceof PrismaClientKnownRequestError) {
       // Handle Prisma specific errors
       switch (exception.code) {
@@ -50,13 +63,17 @@ export class AllExceptionsFilter implements ExceptionFilter {
       message = exception.message;
     }
 
-    const errorObj = {
+    const errorObj: Record<string, any> = {
       statusCode: status,
       timestamp: new Date().toISOString(),
       path: request.url,
       method: request.method,
       message: message,
     };
+
+    if (errors) {
+      errorObj.errors = errors;
+    }
 
     this.logger.error(
       `${request.method} ${request.url} ${status}`,

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,7 +1,7 @@
 import { NestFactory } from '@nestjs/core';
 import { AppModule } from './app.module';
 import * as compression from 'compression';
-import { ValidationPipe, RequestMethod } from '@nestjs/common';
+import { ValidationPipe, RequestMethod, BadRequestException, Logger } from '@nestjs/common';
 import { AllExceptionsFilter } from './common/filters';
 import { DocumentBuilder, SwaggerModule } from '@nestjs/swagger';
 import { LoggingInterceptor } from './common/interceptors/logging.interceptor';
@@ -36,11 +36,13 @@ async function bootstrap() {
         transform: true,
         forbidNonWhitelisted: true,
         exceptionFactory: (errors) => {
+          const logger = new Logger('ValidationPipe');
           const messages = errors.map((err) => ({
             field: err.property,
             constraints: err.constraints,
           }));
-          return new (require('@nestjs/common').BadRequestException)({
+          logger.error(`Validation failed: ${JSON.stringify(messages)}`);
+          return new BadRequestException({
             message: 'Validation failed',
             errors: messages,
           });


### PR DESCRIPTION
- AllExceptionsFilter now includes the `errors` array from HttpException responses in the JSON body and logs it to console
- ValidationPipe exceptionFactory logs field-level constraint violations before throwing BadRequestException
- Replace inline require('@nestjs/common') with static import